### PR TITLE
upgrade action to v2 to support any kind of image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11.9-alpine
-ARG VERSION="0.8.0"
+ARG VERSION=""
 
 RUN apk add --no-cache git
 RUN python -m pip install --no-cache-dir --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+DMC_VERSION = "0.8.0"
+
+IMAGE_NAME = hardcoretech/django-migration-checker
+IMAGE_TAG ?= latest
+IMAGE = $(IMAGE_NAME):$(IMAGE_TAG)
+
+AWS_REGION ?= us-west-2
+AWS_ACCOUNT_ID ?= xxxx
+AWS_ECR_REPO = "$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com"
+
+
+.PHONY: build push-to-aws-ecr push-to-docker-hub
+
+build:
+	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) --build-arg="VERSION=$(DMC_VERSION)" --platform linux/amd64 .
+
+push-to-aws-ecr: build
+	aws ecr describe-repositories --repository-names $(IMAGE_NAME) > /dev/null 2>&1 || aws ecr create-repository --repository-name $(IMAGE_NAME)
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(AWS_ECR_REPO)
+
+	docker tag $(IMAGE_NAME):$(IMAGE_TAG) ${AWS_ECR_REPO}/$(IMAGE_NAME):$(IMAGE_TAG)
+	docker push ${AWS_ECR_REPO}/$(IMAGE_NAME):$(IMAGE_TAG)
+
+push-to-docker-hub: build
+	docker login
+	docker push $(IMAGE_NAME):$(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -28,14 +28,28 @@ jobs:
           fetch-depth: 1
 
       - name: Django Migration Checker
-        uses: hardcoretech/django-migration-checker-action@v1
+        uses: hardcoretech/django-migration-checker-action@v2
         with:
           app-path: app
+          docker-image-tag: 0.8.0
 ```
 
 #### parameter
 inputs
 * `app-path`: django app folder path. after `action/checkout`, the working dir would be repository root.
+* `docker-image`: docker image name. you are able to change the image hub to private source.
+* `docker-image-tag` docker image tag, it should represent version of `django-migration-checker` (python package)
+
+
+## Develop
+Why do we need to maintain docker image rather than build it directly in github action?
+* Provide the capability for CI environment to use the image to do the checking as well.
+
+If django-migration-checker package upgraded, need to update and push docker image. Doesn't need to release new github action version. And the version should match with python package version.
+* `make push-to-aws-ecr DMC_VERSION=<new version> IMAGE_TAG=<new version> AWS_ACCOUNT_ID=<aws account id>`
+* `make push-to-docker-hub DMC_VERSION=<new version> IMAGE_TAG=<new version>`
+
+Only upgrade the version of github action when you change the content of `action.yml`.
 
 
 ## Resource

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ jobs:
 #### parameter
 inputs
 * `app-path`: django app folder path. after `action/checkout`, the working dir would be repository root.
+  * default: `app`
 * `docker-image`: docker image name. you are able to change the image hub to private source.
+  * default: `docker://hardcoretech/django-migration-checker`
 * `docker-image-tag` docker image tag, it should represent version of `django-migration-checker` (python package)
+  * default: `latest`
 
 
 ## Develop

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,16 @@ inputs:
     required: true
     default: 'app'
 
+  docker-image:
+    description: 'docker image name'
+    default: 'docker://hardcoretech/django-migration-checker'
+
+  docker-image-tag:
+    description: 'docker image tag of django-migration-checker'
+    default: 'latest'
+
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  args: 
+  using: docker
+  image: "${{ docker-image }}:${{ docker-image-tag }}"
+  args:
     - ${{ inputs.app-path }}


### PR DESCRIPTION
Why need this change ? / Root Cause :
--------------
upgrade action to v2 to support any kind of image tag

Changed Made :
--------------
* update README to support latest v2 for github action
* add Makefile to push new docker image to AwsECR & DockerHub

Test Scope / Change Impact :
--------------
Need to test the new Github Action